### PR TITLE
Fix colors in webmanifest

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -13,7 +13,5 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
   "display": "standalone"
 }


### PR DESCRIPTION
Fixes an issue mainly noticeable on mobile. Affects the status bar colour, and the background colour when overscrolling. See screenshots below.

| before | after |
| :----: | :---: |
| <img src="https://github.com/kbujari/kleidi.ca/assets/25471061/f4ca0132-f51b-4793-b793-2476ab5fb38d" width=50% height=50%> | <img src="https://github.com/kbujari/kleidi.ca/assets/25471061/a31a1e05-ea94-437d-a6e5-9cc8153b5aa6" width=50% height=50%> |

By default, modern mobile browsers infer the colour they should use for the status bar and page background. By explicitly including a `theme_color` and `background-color`, you override this automatic behaviour.